### PR TITLE
fix(fluency): stop flagging doc placeholders & prose folder names as broken refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to MemoryOS (formerly Second Brain Health Check) are documen
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Reference Integrity false positives: the fluency reference scanner flagged documentation as broken links, depressing the Fluency score for healthy brains. Two classes are now excluded in `dist/fluency/reference-integrity.js`:
+  - **Template/placeholder tokens** — `personal/biznes/YYYY/MM/`, `session/task-XXXX-description`, `memory/episodic/domain/YYYY-MM-DD-slug.md`, and `[Name].tsx`-style bracketed paths are path *shapes* in docs, not references to resolve. Excluded via `YYYY`, `X{3,}`, `\bslug\b`, and `[<>[]{}]` filters.
+  - **Bare single-segment directory labels** — sub-folders named in prose relative to a parent path stated earlier in the same sentence (e.g. `faktury-sprzedaz/`, `faktury-kosztowe/`, `bank-statements/`, `outreach/`, `zips/`) are too ambiguous to resolve at repo root. A directory token with no parent path (`^[^/]+\/$`) is no longer flagged. Files are unaffected. Tradeoff: a genuinely-typo'd bare top-level directory reference will no longer be caught; path-qualified references still are.
+- Added `test/reference-integrity.test.js` covering both false-positive classes plus true-positive checks (real dangling refs in CLAUDE.md and skills must still fail).
+
 ## [0.18.5] - 2026-03-17
 
 ### Fixed

--- a/dist/fluency/reference-integrity.js
+++ b/dist/fluency/reference-integrity.js
@@ -53,6 +53,19 @@ const EXCLUDE_PATTERNS = [
     /^personal\//,          // personal directory paths
     /^blog\//,              // blog content paths
     /^growth\//,            // growth directory paths
+    // --- Template / placeholder tokens, not real paths (task-3552) ---
+    // Skill docs and CLAUDE.md describe path *shapes* with placeholders. These
+    // are documentation, not references Claude should resolve.
+    /YYYY/,                 // year placeholder: personal/biznes/YYYY/MM/, YYYY-MM-DD-slug.md
+    /X{3,}/,                // id placeholder: task-XXXX, task-XXX
+    /\bslug\b/i,            // slug placeholder: memory/episodic/domain/YYYY-MM-DD-slug.md
+    /[<>[\]{}]/,            // bracketed template tokens: [Name].tsx, <id>, {{VAR}}
+    // --- Bare single-segment directory labels mentioned in prose (task-3552) ---
+    // A directory token with no parent path (e.g. "zips/", "faktury-kosztowe/")
+    // is almost always a sub-folder named in prose relative to a parent path
+    // stated earlier in the same sentence — too ambiguous to resolve at root.
+    // Trailing "/" scopes this to directories only; files are unaffected.
+    /^[^/]+\/$/,            // e.g. "outreach/", "bank-statements/", "faktury-sprzedaz/"
 ];
 
 // Stricter path patterns for skills — only match references to documentation-like files

--- a/test/reference-integrity.test.js
+++ b/test/reference-integrity.test.js
@@ -1,0 +1,102 @@
+/**
+ * Reference Integrity — false-positive regression tests (task-3552)
+ *
+ * The scanner must NOT flag template placeholders or bare prose folder names
+ * as broken references, but MUST still catch genuinely dangling file paths.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkReferenceIntegrity } from '../dist/fluency/reference-integrity.js';
+
+async function makeBrain(files) {
+    const root = await mkdtemp(join(tmpdir(), 'sbhc-refint-'));
+    for (const [rel, content] of Object.entries(files)) {
+        const full = join(root, rel);
+        await mkdir(join(full, '..'), { recursive: true });
+        await writeFile(full, content, 'utf-8');
+    }
+    return root;
+}
+
+function claudeCheck(result) {
+    return result.checks.find(c => c.name === 'CLAUDE.md references resolve');
+}
+function skillCheck(result) {
+    return result.checks.find(c => c.name === 'Skill references resolve');
+}
+
+test('template placeholders in CLAUDE.md are not flagged as broken', async () => {
+    const root = await makeBrain({
+        'CLAUDE.md': [
+            '# CLAUDE.md',
+            '- Canonical folder per month: `personal/biznes/YYYY/MM/` holds',
+            '  `faktury-sprzedaz/`, `faktury-kosztowe/`, `bank-statements/`,',
+            '  `outreach/`, and `zips/`.',
+            '- Session branch: `session/task-XXXX-description`',
+            '- Episodic note: `memory/episodic/domain/YYYY-MM-DD-slug.md`',
+            '- Real doc: `docs/REAL.md`',
+        ].join('\n'),
+        'docs/REAL.md': '# real',
+    });
+    try {
+        const result = await checkReferenceIntegrity(root);
+        const c = claudeCheck(result);
+        assert.equal(c.status, 'pass', `expected pass, got: ${c.message}`);
+    } finally {
+        await rm(root, { recursive: true, force: true });
+    }
+});
+
+test('genuinely broken CLAUDE.md reference is still caught', async () => {
+    const root = await makeBrain({
+        'CLAUDE.md': '# CLAUDE.md\nProfile: `memory/personal-profile.md`\n',
+    });
+    try {
+        const result = await checkReferenceIntegrity(root);
+        const c = claudeCheck(result);
+        assert.notEqual(c.status, 'pass', 'a real dangling ref must not pass');
+        assert.match(c.message, /personal-profile\.md/);
+    } finally {
+        await rm(root, { recursive: true, force: true });
+    }
+});
+
+test('placeholder example paths in skills are not flagged', async () => {
+    const root = await makeBrain({
+        'CLAUDE.md': '# CLAUDE.md\n',
+        '.claude/skills/demo/SKILL.md': [
+            '# Demo',
+            'Write to `memory/episodic/sessions/YYYY-MM-DD-task-XXXX.md`.',
+            'See `memory/procedural/domain/workflow-name.md` example.',
+            'Read `docs/REAL.md`.',
+        ].join('\n'),
+        'docs/REAL.md': '# real',
+        'memory/procedural/domain/workflow-name.md': '# wf',
+    });
+    try {
+        const result = await checkReferenceIntegrity(root);
+        const c = skillCheck(result);
+        assert.equal(c.status, 'pass', `expected pass, got: ${c.message}`);
+    } finally {
+        await rm(root, { recursive: true, force: true });
+    }
+});
+
+test('genuinely broken skill reference is still caught', async () => {
+    const root = await makeBrain({
+        'CLAUDE.md': '# CLAUDE.md\n',
+        '.claude/skills/demo/SKILL.md':
+            '# Demo\nPull strategy: `memory/linkedin-content-strategy.md`\n',
+    });
+    try {
+        const result = await checkReferenceIntegrity(root);
+        const c = skillCheck(result);
+        assert.notEqual(c.status, 'pass', 'a real dangling skill ref must not pass');
+        assert.match(c.message, /linkedin-content-strategy\.md/);
+    } finally {
+        await rm(root, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Problem

The **Reference Integrity** fluency layer (`dist/fluency/reference-integrity.js`) treats documentation as broken file references. On a real, healthy brain (iwoszapar.com, v0.18.5 scan) it reported:

- *CLAUDE.md references resolve* → `9/34 references are broken. Top issues: memory/personal-profile.md, faktury-sprzedaz/, faktury-kosztowe/`
- *Skill references resolve* → `25/144 skill references broken`

But most of those aren't broken links — they're documentation. Two false-positive classes dominate the noise:

1. **Template / placeholder tokens.** Skill docs and CLAUDE.md describe path *shapes*, not real paths:
   - `personal/biznes/YYYY/MM/` (a monthly-folder convention)
   - `session/task-XXXX-description` (branch naming)
   - `memory/episodic/domain/YYYY-MM-DD-slug.md` (example episodic note)
   - `[Name].tsx` / `<id>` / `{{VAR}}` bracketed tokens

2. **Bare single-segment directory labels named in prose.** A sentence like *"`personal/biznes/YYYY/MM/` holds `faktury-sprzedaz/`, `faktury-kosztowe/`, `bank-statements/`, `outreach/`, and `zips/`"* lists sub-folders **relative to the parent path stated earlier in the same sentence**. The scanner resolves each one against repo root, where they don't exist, and flags all five.

These inflate the broken-ref count and depress Fluency for brains that are actually well-referenced — which undercuts trust in the metric.

## Fix

Add targeted entries to `EXCLUDE_PATTERNS` (applied at extraction time, before the existence check):

```js
/YYYY/,       // year placeholder: personal/biznes/YYYY/MM/, YYYY-MM-DD-slug.md
/X{3,}/,      // id placeholder: task-XXXX, task-XXX
/\bslug\b/i,  // slug placeholder
/[<>[\]{}]/,  // bracketed template tokens: [Name].tsx, <id>, {{VAR}}
/^[^/]+\/$/,  // bare single-segment dir label: outreach/, faktury-sprzedaz/
```

The last rule is scoped to **directories only** (trailing `/`); files are unaffected.

### Tradeoff (called out honestly)

The bare-directory rule means a genuinely-typo'd **bare top-level directory** reference (e.g. someone writes `documantation/` meaning a real `documentation/`) will no longer be flagged. Path-qualified references (`docs/foo.md`, `memory/bar/`) are still fully checked. This is a deliberate trade: the bare-single-segment class is overwhelmingly prose, and the rule only suppresses tokens that *also* fail to resolve.

## Tests

New `test/reference-integrity.test.js` — first coverage for this layer:
- ✅ template placeholders in CLAUDE.md → **pass** (not flagged)
- ✅ placeholder example paths in skills → **pass** (not flagged)
- ✅ genuinely broken CLAUDE.md ref (`memory/personal-profile.md`) → **still caught**
- ✅ genuinely broken skill ref (`memory/linkedin-content-strategy.md`) → **still caught**

Full suite green (55 tests, `node --test`). No version bump — left under `[Unreleased]` for the maintainer to assign on release.

## Note

`dist/` is the hand-authored ESM source in this repo (no `src/` / build step), so the patch edits `dist/fluency/reference-integrity.js` directly, consistent with the rest of the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)