### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm test
+      - run: npm install -g npm@latest
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-<a href="https://www.npmjs.com/package/@iwo-szapar/second-brain-health-check"><img src="https://img.shields.io/npm/v/memory-os?style=flat-square&color=222" alt="npm version" /></a>
+<a href="https://www.npmjs.com/package/@iwo-szapar/second-brain-health-check"><img src="https://img.shields.io/npm/v/@iwo-szapar/second-brain-health-check?style=flat-square&color=222" alt="npm version" /></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-222?style=flat-square" alt="License: MIT" /></a>
 <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D20-222?style=flat-square" alt="Node" /></a>
 <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-compatible-222?style=flat-square" alt="MCP Compatible" /></a>
@@ -402,6 +402,42 @@ Open that file, find the old `"memoryos"` entry under `"mcpServers"`, and replac
 ```
 
 Then restart the app.
+
+---
+
+## Release Process
+
+Publishing uses npm trusted publishing from GitHub Actions. The workflow in `.github/workflows/publish.yml` runs when a GitHub release is published, then executes:
+
+```bash
+npm ci
+npm test
+npm install -g npm@latest
+npm publish --access public
+```
+
+The workflow intentionally does not use `NPM_TOKEN`. npm authenticates the publish through GitHub Actions OIDC, so the package must have this trusted publisher configured on npm:
+
+| Field | Value |
+|:------|:------|
+| Publisher | GitHub Actions |
+| Organization/user | `iwo-szapar` |
+| Repository | `second-brain-health-check` |
+| Workflow filename | `publish.yml` |
+| Environment | *(empty)* |
+
+Before publishing a release:
+1. Update `package.json` and `CHANGELOG.md`.
+2. Open a release PR and wait for CI on Ubuntu and Windows.
+3. Merge the PR.
+4. Create a GitHub release for the matching tag, for example `v0.18.7`.
+5. Verify npm `latest` after the publish workflow completes:
+
+```bash
+npm view @iwo-szapar/second-brain-health-check version dist-tags --json
+```
+
+If publish fails with `ENEEDAUTH`, check that the npm trusted publisher fields match the table exactly and that `package.json` `repository.url` points to `git+https://github.com/iwo-szapar/second-brain-health-check.git`.
 
 ### Windows: path errors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "memory-os",
+  "name": "@iwo-szapar/second-brain-health-check",
   "version": "0.18.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "memory-os",
+      "name": "@iwo-szapar/second-brain-health-check",
       "version": "0.18.6",
       "license": "MIT",
       "dependencies": {
@@ -13,16 +13,16 @@
         "zod": "^3.25.0"
       },
       "bin": {
-        "memory-os": "dist/cli.js"
+        "second-brain-health-check": "dist/cli.js"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -415,12 +415,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -439,9 +439,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -576,9 +576,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -627,9 +627,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -808,9 +808,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -840,9 +840,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iwo-szapar/memory-os.git"
+    "url": "git+https://github.com/iwo-szapar/second-brain-health-check.git"
   },
-  "homepage": "https://github.com/iwo-szapar/memory-os#readme",
+  "homepage": "https://github.com/iwo-szapar/second-brain-health-check#readme",
   "bugs": {
-    "url": "https://github.com/iwo-szapar/memory-os/issues"
+    "url": "https://github.com/iwo-szapar/second-brain-health-check/issues"
   }
 }


### PR DESCRIPTION
Refs #16\n\n## Summary\n- remove token-based npm auth from the release publish workflow\n- use Node 24 + latest npm before npm publish so GitHub Actions can use npm OIDC trusted publishing\n- correct package repository metadata to this repo, which npm trusted publishing matches against\n- document the release flow and the exact npm trusted-publisher fields\n- refresh the lockfile to the current package name/bin and patched transitive versions\n\n## Validation\n- npm ci\n- npm test\n- npm audit --omit=dev\n- npm pack --dry-run\n- npm publish --dry-run --access public (reaches publish validation; expected stop because 0.18.6 already exists)\n- actionlint on ci.yml and publish.yml\n\n## Note\nThe npm package settings still need the trusted publisher configured as documented before the next release: GitHub Actions, owner iwo-szapar, repo second-brain-health-check, workflow publish.yml, no environment.